### PR TITLE
Zero-dim fix & Dynamic output to static input cluster deassign

### DIFF
--- a/openvino_tensorflow/ie_vadm_engine.cc
+++ b/openvino_tensorflow/ie_vadm_engine.cc
@@ -138,18 +138,6 @@ void IE_VADM_Engine::infer(
       outputs[i] = std::make_shared<IETensor>(blob);
     }
   }
-
-  for (int i = 0; i < in_blobs.size(); i++) {
-    in_blobs[i]->deallocate();
-  }
-  for (int i = 0; i < out_blobs.size(); i++) {
-    if (out_blobs[i] != nullptr) {
-      out_blobs[i]->deallocate();
-    }
-  }
-  for (int i = 0; i < param_blobs.size(); i++) {
-    param_blobs[i]->deallocate();
-  }
 }
 }// namespace openvino_tensorflow
 }// namespace tensorflow

--- a/openvino_tensorflow/kernels/encapsulate_op.cc
+++ b/openvino_tensorflow/kernels/encapsulate_op.cc
@@ -50,6 +50,8 @@ class NGraphEncapsulateOp : public OpKernel {
   std::vector<bool> m_input_is_static;
   std::list<std::string> m_lru;
   std::unordered_map<std::string, std::shared_ptr<Executable>> m_ng_exec_map;
+  ngraph::ResultVector ng_result_list;
+  std::vector<ngraph::Shape> ng_output_shapes;
 };
 
 static Status ParseNodeAttributes(
@@ -198,8 +200,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   Timer function_lookup_or_create;
 
   bool multi_req_execution = false;
-  if (std::getenv("OPENVINO_TF_ENABLE_BATCHING") &&
-      NGraphClusterManager::NumberOfClusters() == 1) {
+  if (std::getenv("OPENVINO_TF_ENABLE_BATCHING")) {
     NGRAPH_VLOG(2) << "Batching is enabled" << name();
     multi_req_execution = true;
   }
@@ -241,6 +242,8 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
       for (int j = 0; j < tf_input_tensors[i].shape().dims(); ++j) {
         ng_shape[j] = tf_input_tensors[i].shape().dim_size(j);
       }
+      if (ng_shape.size() > 0 && ng_shape[0] == 0)
+          continue;
       ngraph::element::Type ng_element_type;
       OP_REQUIRES_OK(ctx, util::TFDataTypeToNGraphElementType(
                               tf_input_tensors[i].dtype(), &ng_element_type));
@@ -268,23 +271,29 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
   auto results = ng_exec->GetResults();
   std::string device;
   BackendManager::GetBackendName(device);
-  std::vector<shared_ptr<ngraph::runtime::Tensor>> ng_outputs(results.size(),
+  std::vector<shared_ptr<ngraph::runtime::Tensor>> ng_func_outputs(results.size(),
+                                                              nullptr);
+  std::vector<shared_ptr<ngraph::runtime::Tensor>> ng_outputs(ng_result_list.size(),
                                                               nullptr);
   std::vector<int> dyn_shape_tensors;
-  if(device != "MYRIAD" && device != "VAD-M"){
-    for (auto i = 0; i < results.size(); i++) {
-      auto ng_element = results[i];
+  std::vector<int> output_mappings(ng_result_list.size(), -1);
+  int j = 0;
+  if(device != "MYRIAD" && device != "HDDL"){
+    for (auto i = 0; i < ng_result_list.size(); i++) {
+      auto ng_element = ng_result_list[i];
       if (ng_element->get_output_partial_shape(0).is_dynamic()) {
         NGRAPH_VLOG(4)
             << "NGraphEncapsulateOp::Compute skipping output allocation for "
               "dynamic tensor at index"
             << i;
         dyn_shape_tensors.push_back(i);
+        output_mappings[i] = j;
+        j++;
         continue;
       }
 
       // Create the TF output tensor
-      auto ng_shape = ng_exec->GetOutputShape(i);
+      auto ng_shape = ng_output_shapes[i];
       TensorShape tf_shape;
       for (auto dim : ng_shape) {
         tf_shape.AddDim(dim);
@@ -310,6 +319,10 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
         ng_outputs[i] =
           make_shared<IETensor>(ng_element_type, ng_shape, output_tensor->data());
       #endif
+      if (!(ng_shape.size() > 0 && ng_shape[0] == 0)) {
+          output_mappings[i] = j;
+          ng_func_outputs[j++] = ng_outputs[i];
+      }
     }
   }
   NGRAPH_VLOG(4)
@@ -327,7 +340,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
           << "NGraphEncapsulateOp::Compute call starting for cluster "
           << m_cluster_id;
       try {
-        ng_exec->Call(ng_inputs, ng_outputs, multi_req_execution);
+        ng_exec->Call(ng_inputs, ng_func_outputs, multi_req_execution);
       } catch (const std::exception& exp) {
         string status_string = "Caught exception while executing cluster " +
                                to_string(m_cluster_id) + ": " +
@@ -341,9 +354,12 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     }
     time_execute_function = execute_function.ElapsedInMS();
   }
-  if(device != "MYRIAD" && device != "VAD-M"){
+  if(device != "MYRIAD" && device != "HDDL"){
     for (auto i : dyn_shape_tensors) {
-      auto ng_output = ng_outputs[i];
+      OP_REQUIRES(ctx, output_mappings[i] != -1,
+              errors::Internal("Mapping error while "
+                               "reading dynamic output blob"));
+      auto ng_output = ng_func_outputs[output_mappings[i]];
       // Create the TF output tensor
       auto ng_shape = ng_output->get_shape();
       TensorShape tf_shape;
@@ -359,33 +375,59 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
     }
   }
   else{
-    for(int i = 0; i < results.size(); i++){
-      auto ng_output = ng_outputs[i];
+    int j = 0;
+    for(int i = 0; i < ng_result_list.size(); i++){
+      if (ng_output_shapes[i].size() > 0 && ng_output_shapes[i][0] == 0) {
 
-      auto ng_shape = ng_exec->GetOutputShape(i);
-      ngraph::element::Type expected_elem_type;
-      auto ng_element = results[i];
-      auto ng_element_type = ng_element->get_element_type();
-      OP_REQUIRES_OK(
-        ctx, util::TFDataTypeToNGraphElementType(ctx->expected_output_dtype(i),
-                                                 &expected_elem_type));
-      OP_REQUIRES(
-          ctx, ng_element_type == expected_elem_type,
-          errors::Internal("Element type inferred by nGraph does not match "
-                          "the element type expected by TensorFlow"));
-      TensorShape tf_shape;
-      for(auto dim : ng_shape) {
-        tf_shape.AddDim(dim);
+        auto ng_shape = ng_output_shapes[i];
+        ngraph::element::Type expected_elem_type;
+        auto ng_element = ng_result_list[i];
+        auto ng_element_type = ng_element->get_element_type();
+        OP_REQUIRES_OK(
+          ctx, util::TFDataTypeToNGraphElementType(ctx->expected_output_dtype(i),
+                                                   &expected_elem_type));
+        OP_REQUIRES(
+            ctx, ng_element_type == expected_elem_type,
+            errors::Internal("Element type inferred by nGraph does not match "
+                            "the element type expected by TensorFlow"));
+        TensorShape tf_shape;
+        for(auto dim : ng_shape) {
+          tf_shape.AddDim(dim);
+        }
+
+        Tensor* output_tensor = nullptr;
+        OP_REQUIRES_OK(ctx, ctx->allocate_output(i, tf_shape, &output_tensor));
+      } else {
+        auto ng_output = ng_func_outputs[j++];
+
+        auto ng_shape = ng_output_shapes[i];
+        if (ng_result_list[i]->is_dynamic()) {
+            ng_shape = ng_output->get_shape();
+        }
+        ngraph::element::Type expected_elem_type;
+        auto ng_element = ng_result_list[i];
+        auto ng_element_type = ng_element->get_element_type();
+        OP_REQUIRES_OK(
+          ctx, util::TFDataTypeToNGraphElementType(ctx->expected_output_dtype(i),
+                                                   &expected_elem_type));
+        OP_REQUIRES(
+            ctx, ng_element_type == expected_elem_type,
+            errors::Internal("Element type inferred by nGraph does not match "
+                            "the element type expected by TensorFlow"));
+        TensorShape tf_shape;
+        for(auto dim : ng_shape) {
+          tf_shape.AddDim(dim);
+        }
+
+        Tensor* output_tensor = nullptr;
+        OP_REQUIRES_OK(ctx, ctx->allocate_output(i, tf_shape, &output_tensor));
+
+        auto size = ng_output->get_size_in_bytes();
+        auto ie_tensor = static_pointer_cast<IETensor>(ng_output);
+        auto blob = ie_tensor->get_blob();
+
+        ng_output->read(output_tensor->data(), size);
       }
-
-      Tensor* output_tensor = nullptr;
-      OP_REQUIRES_OK(ctx, ctx->allocate_output(i, tf_shape, &output_tensor));
-
-      auto size = ng_output->get_size_in_bytes();
-      auto ie_tensor = static_pointer_cast<IETensor>(ng_output);
-      auto blob = ie_tensor->get_blob();
-
-      ng_output->read(output_tensor->data(), size);
     }
   }
 
@@ -455,10 +497,22 @@ Status NGraphEncapsulateOp::GetExecutable(
     long vm, rss, vm0, rss0;
     util::MemoryProfile(vm0, rss0);
 
+    ng_result_list.clear();
+    ng_output_shapes.clear();
     NGRAPH_VLOG(1) << "Compilation cache miss: " << m_name;
     TF_RETURN_IF_ERROR(Builder::TranslateGraph(input_shapes, static_input_map,
-                                               &m_graph, m_name, ng_function));
+                                               &m_graph, m_name, ng_function,
+                                               ng_result_list));
     util::DumpNGGraph(ng_function, m_name);
+
+    ng_output_shapes.resize(ng_result_list.size());
+    for (int i=0; i<ng_result_list.size(); i++) {
+        if (ng_result_list[i]->is_dynamic()) {
+            ng_output_shapes[i] = ngraph::Shape{};
+        } else {
+            ng_output_shapes[i] = ng_result_list[i]->get_shape();
+        }
+    }
 
     // Evict the cache if the number of elements exceeds the limit
     std::shared_ptr<Executable> evicted_ng_exec;

--- a/openvino_tensorflow/ovtf_builder.cc
+++ b/openvino_tensorflow/ovtf_builder.cc
@@ -2474,11 +2474,17 @@ static Status TranslateSqueezeOp(const Node* op,
     tf_axis[i] = tf_axis[i] < 0 ? (int32)(input_dims) + tf_axis[i] : tf_axis[i];
   }
 
-  auto ng_const = ConstructNgNode<opset::Constant>(
-      op->name(), ng::element::i32, ng::Shape{tf_axis.size()}, tf_axis);
+  if (input_dims > 0 && ng_input.get_shape()[0] == 0) {
+    SaveNgOp(ng_op_map, op->name(),
+             ConstructNgNode<opset::Constant>(op->name(), ng_input.get_element_type(),
+                                         ngraph::Shape{0}, std::vector<int>({0})));
+  } else {
+    auto ng_const = ConstructNgNode<opset::Constant>(
+        op->name(), ng::element::i32, ng::Shape{tf_axis.size()}, tf_axis);
 
-  SaveNgOp(ng_op_map, op->name(),
-           ConstructNgNode<opset::Squeeze>(op->name(), ng_input, ng_const));
+    SaveNgOp(ng_op_map, op->name(),
+             ConstructNgNode<opset::Squeeze>(op->name(), ng_input, ng_const));
+  }
   return Status::OK();
 }
 
@@ -2638,6 +2644,8 @@ static Status TranslateUnpackOp(const Node* op,
     std::vector<int64_t> new_axis_mask(rank, 0);
     std::vector<int64_t> shrink_axis_mask(rank, 0);
     shrink_axis_mask[tf_axis] = 1;
+    if (input_shape.size() == 1)
+      shrink_axis_mask[tf_axis] = 0;
     auto slice = ConstructNgNode<opset::StridedSlice>(
         op->name(), ng_input, ng_begin, ng_end, begin_mask, end_mask,
         new_axis_mask, shrink_axis_mask);
@@ -2829,11 +2837,24 @@ const static std::map<
         {"Xdivy", TranslateXdivyOp},
         {"ZerosLike", TranslateZerosLikeOp}};
 
+
 Status Builder::TranslateGraph(
     const std::vector<TensorShape>& inputs,
     const std::vector<const Tensor*>& static_input_map,
     const Graph* input_graph, const string name,
     shared_ptr<ng::Function>& ng_function) {
+  ng::ResultVector ng_result_list;
+  TranslateGraph(inputs, static_input_map, input_graph,
+          name, ng_function, ng_result_list);
+  return Status::OK();
+}
+
+Status Builder::TranslateGraph(
+    const std::vector<TensorShape>& inputs,
+    const std::vector<const Tensor*>& static_input_map,
+    const Graph* input_graph, const string name,
+    shared_ptr<ng::Function>& ng_function,
+    ng::ResultVector& ng_result_list) {
   //
   // We will visit ops in topological order.
   //
@@ -2879,6 +2900,8 @@ Status Builder::TranslateGraph(
   // Populate the parameter list, and also put parameters into the op map.
   //
   ng::ParameterVector ng_parameter_list(tf_params.size());
+  ng::ParameterVector ng_func_parameter_list;
+  ng_func_parameter_list.reserve(tf_params.size());
 
   for (auto parm : tf_params) {
     DataType dtype;
@@ -2901,7 +2924,13 @@ Status Builder::TranslateGraph(
     GetNodeAttr(parm->attrs(), "_prov_tag", &prov_tag);
     auto ng_param =
         ConstructNgNode<opset::Parameter>(prov_tag, ng_et, ng_shape);
-    SaveNgOp(ng_op_map, parm->name(), ng_param);
+    if (ng_shape.size() > 0 && ng_shape[0] == 0) {
+        std::vector<std::string> constant_values(ng::shape_size(ng_shape), "0");
+        auto ng_const_input = ConstructNgNode<opset::Constant>(prov_tag, ng_et, ng_shape, constant_values);
+        SaveNgOp(ng_op_map, parm->name(), ng_const_input);
+    } else {
+        SaveNgOp(ng_op_map, parm->name(), ng_param);
+    }
     ng_parameter_list[index] =
         ngraph::as_type_ptr<opset::Parameter>(ng_param.get_node_shared_ptr());
   }
@@ -2943,7 +2972,9 @@ Status Builder::TranslateGraph(
   //
   // Populate the result list.
   //
-  ng::ResultVector ng_result_list(tf_ret_vals.size());
+  ng_result_list.resize(tf_ret_vals.size());
+  ng::ResultVector ng_func_result_list;
+  ng_func_result_list.reserve(tf_params.size());
 
   for (auto n : tf_ret_vals) {
     // Make sure that this _Retval only has one input node.
@@ -2963,12 +2994,20 @@ Status Builder::TranslateGraph(
     ng_result_list[index] =
         ngraph::as_type_ptr<opset::Result>(ng_result.get_node_shared_ptr());
   }
+  for (int i=0; i<ng_parameter_list.size(); i++) {
+    if (!(ng_parameter_list[i]->get_shape().size() > 0 && ng_parameter_list[i]->get_shape()[0] == 0))
+      ng_func_parameter_list.push_back(ng_parameter_list[i]);
+  }
+  for (int i=0; i<ng_result_list.size(); i++) {
+    if (ng_result_list[i]->is_dynamic() || !(ng_result_list[i]->get_shape().size() > 0 && ng_result_list[i]->get_shape()[0] == 0))
+      ng_func_result_list.push_back(ng_result_list[i]);
+  }
 
   //
   // Create the nGraph function.
   //
   ng_function =
-      make_shared<ng::Function>(ng_result_list, ng_parameter_list, name);
+      make_shared<ng::Function>(ng_func_result_list, ng_func_parameter_list, name);
 
   //
   // Apply additional passes on the nGraph function here.

--- a/openvino_tensorflow/ovtf_builder.h
+++ b/openvino_tensorflow/ovtf_builder.h
@@ -24,6 +24,12 @@ class Builder {
       const std::vector<const Tensor*>& static_input_map, const Graph* tf_graph,
       const string name, std::shared_ptr<ngraph::Function>& ng_function);
 
+  static Status TranslateGraph(
+      const std::vector<TensorShape>& inputs,
+      const std::vector<const Tensor*>& static_input_map, const Graph* tf_graph,
+      const string name, std::shared_ptr<ngraph::Function>& ng_function,
+      ngraph::ResultVector& ng_func_result_list);
+
   using OpMap = std::unordered_map<std::string,
                                    std::vector<ngraph::Output<ngraph::Node>>>;
   using ConstMap = std::map<


### PR DESCRIPTION
Zero-dim error fixed by bypassing zero-dim nodes in execution. A pass added to deassign clusters which have dynamic shape going to nodes with translations using get_shape().