### PR TITLE
Added device type for custom myriad dev types

### DIFF
--- a/openvino_tensorflow/backend.cc
+++ b/openvino_tensorflow/backend.cc
@@ -25,12 +25,35 @@ Backend::Backend(const string& config) {
   InferenceEngine::Core core;
   auto devices = core.GetAvailableDevices();
   // TODO: Handle multiple devices
+
+  bool dev_found = false;
   if (find(devices.begin(), devices.end(), device) == devices.end()) {
+
+    if(device == "MYRIAD"){
+      for(auto dev : devices){
+        if(dev.find(device) != std::string::npos)
+          dev_found = true;
+      }
+    }
+  }
+  else{
+    dev_found = true;
+  }
+
+  if(!dev_found){
+
     stringstream ss;
     ss << "Device '" << config << "' not found.";
     throw runtime_error(ss.str());
+
   }
-  m_device = config;
+  Backend::GetGlobalContext().device_type = config;
+  if(config.find("MYRIAD") != std::string::npos){
+    m_device = "MYRIAD";
+  }
+  else{
+    m_device = config;
+  }
 }
 
 shared_ptr<Executable> Backend::Compile(shared_ptr<ngraph::Function> func,

--- a/openvino_tensorflow/backend_manager.cc
+++ b/openvino_tensorflow/backend_manager.cc
@@ -25,6 +25,12 @@ Status BackendManager::SetBackend(const string& backend_name) {
   OVTF_VLOG(2) << "BackendManager::SetBackend(" << backend_name << ")";
   shared_ptr<Backend> backend;
   string bname(backend_name);
+  if(bname == "HDDL"){
+    return errors::Internal("Failed to set backend: ", bname + " backend not available");
+  }
+  if(bname == "VAD-M")
+    bname = "HDDL";
+
   auto status = CreateBackend(backend, bname);
   if (!status.ok() || backend == nullptr) {
     return errors::Internal("Failed to set backend: ", status.error_message());
@@ -32,7 +38,12 @@ Status BackendManager::SetBackend(const string& backend_name) {
 
   lock_guard<mutex> lock(m_backend_mutex);
   m_backend = backend;
-  m_backend_name = bname;
+  if(bname.find("MYRIAD") != string::npos){
+    m_backend_name = "MYRIAD";
+  }
+  else{
+    m_backend_name = bname;
+  }
   return Status::OK();
 }
 

--- a/openvino_tensorflow/contexts.h
+++ b/openvino_tensorflow/contexts.h
@@ -14,6 +14,7 @@ namespace openvino_tensorflow {
 
 struct GlobalContext {
   InferenceEngine::Core ie_core;
+  std::string device_type;
 };
 
 } // namespace openvino_tensorflow

--- a/openvino_tensorflow/ie_backend_engine.cc
+++ b/openvino_tensorflow/ie_backend_engine.cc
@@ -46,7 +46,8 @@ void IE_Backend_Engine::load_network() {
   }
 
   // Load network to the plugin (m_device)
-  m_exe_network = Backend::GetGlobalContext().ie_core.LoadNetwork(m_network, m_device, config);
+  auto dev_type = Backend::GetGlobalContext().device_type;
+  m_exe_network = Backend::GetGlobalContext().ie_core.LoadNetwork(m_network, dev_type, config);
   m_network_ready = true;
 }
 


### PR DESCRIPTION
* Removed HDDL option from set_backend, so user can't use HDDL. Users have to use VAD-M.
* Used device type to allow for custom myriad device types