### PR TITLE
Make CI use binary OpenVINO

### DIFF
--- a/test/ci/azure/cpu.yml
+++ b/test/ci/azure/cpu.yml
@@ -11,6 +11,7 @@
  variables:
     WORK_DIR: $(Pipeline.Workspace)/openvino_tensorflow
     BUILD_DIR: $(WORK_DIR)/build
+    OV_LOCATION: /opt/intel/openvino_2021.2.185/
     
  steps:
  
@@ -26,7 +27,6 @@
  
    - script: |
       export TF_LOCATION=/home/iotgecsp/setup/artifacts/tensorflow
-      export OV_LOCATION=/opt/intel/openvino_2021.2.185/ 
       export OPENVINO_TF_BACKEND=CPU
       export BUILD_OPTIONS=--use_grappler_optimizer
       virtualenv -p python3 /home/iotgecsp/azu_ag/myagent/1/s/venv 
@@ -39,12 +39,13 @@
       echo $(WORK_DIR)
       git submodule init
       git submodule update
-      python3 build_ovtf.py --use_tensorflow_from_location=/home/iotgecsp/setup/artifacts --cxx11_abi_version=1
+      python3 build_ovtf.py --use_tensorflow_from_location=/home/iotgecsp/setup/artifacts --use_openvino_from_location=$(OV_LOCATION) --disable_packaging_openvino_libs --cxx11_abi_version=1
      workingDirectory: $(WORK_DIR) 
      displayName: "Build"
      
    - script: |
       export OPENVINO_TF_BACKEND=CPU
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd` python3 test/ci/azure/test_runner.py \
       --artifacts $(WORK_DIR)/build_cmake/artifacts/ --test_cpp
@@ -53,6 +54,7 @@
      
    - script: |
       export OPENVINO_TF_BACKEND=CPU
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       cd test/ci/azure/
       bash run_inception_v3.sh $(WORK_DIR)/build_cmake/artifacts/
@@ -69,6 +71,7 @@
    - script: |
       export OPENVINO_TF_BACKEND=CPU
       pip install keras
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd`:`pwd`/tools:`pwd`/examples python3 test/ci/azure/test_runner.py \
       --artifacts $(WORK_DIR)/build_cmake/artifacts --test_python
@@ -78,6 +81,7 @@
    - script: |
       export OPENVINO_TF_BACKEND=CPU
       pip install keras
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd` python3 test/ci/azure/test_runner.py \
         --artifacts $(WORK_DIR)/build_cmake/artifacts --test_tf_python

--- a/test/ci/azure/gpu.yml
+++ b/test/ci/azure/gpu.yml
@@ -11,6 +11,7 @@
  variables:
     WORK_DIR: $(Pipeline.Workspace)/openvino_tensorflow
     BUILD_DIR: $(WORK_DIR)/build
+    OV_LOCATION: /opt/intel/openvino_2021.2.185/
     
  steps:
  
@@ -26,7 +27,6 @@
  
    - script: |
       export TF_LOCATION=/home/iotgecsp/setup/artifacts/tensorflow
-      export OV_LOCATION=/opt/intel/openvino_2021.2.185/ 
       export OPENVINO_TF_BACKEND=GPU
       export BUILD_OPTIONS=--use_grappler_optimizer
       virtualenv -p python3 /home/iotgecsp/azu_ag/myagent/6/s/venv 
@@ -39,12 +39,13 @@
       echo $(WORK_DIR)
       git submodule init
       git submodule update
-      python3 build_ovtf.py --use_tensorflow_from_location=/home/iotgecsp/setup/artifacts --cxx11_abi_version=1
+      python3 build_ovtf.py --use_tensorflow_from_location=/home/iotgecsp/setup/artifacts --use_openvino_from_location=$(OV_LOCATION) --disable_packaging_openvino_libs --cxx11_abi_version=1
      workingDirectory: $(WORK_DIR) 
      displayName: "Build"
      
    - script: |
       export OPENVINO_TF_BACKEND=GPU
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd` python3 test/ci/azure/test_runner.py \
       --artifacts $(WORK_DIR)/build_cmake/artifacts/ --test_cpp
@@ -53,6 +54,7 @@
      
    - script: |
       export OPENVINO_TF_BACKEND=GPU
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       cd test/ci/azure/      
       bash run_inception_v3.sh $(WORK_DIR)/build_cmake/artifacts/
@@ -69,6 +71,7 @@
    - script: |
       export OPENVINO_TF_BACKEND=GPU
       pip install keras
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd`:`pwd`/tools:`pwd`/examples python3 test/ci/azure/test_runner.py \
       --artifacts $(WORK_DIR)/build_cmake/artifacts --test_python
@@ -78,6 +81,7 @@
    - script: |
       export OPENVINO_TF_BACKEND=GPU
       pip install keras
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd` python3 test/ci/azure/test_runner.py \
         --artifacts $(WORK_DIR)/build_cmake/artifacts --test_tf_python

--- a/test/ci/azure/myriad.yml
+++ b/test/ci/azure/myriad.yml
@@ -11,6 +11,7 @@
  variables:
     WORK_DIR: $(Pipeline.Workspace)/openvino_tensorflow
     BUILD_DIR: $(WORK_DIR)/build
+    OV_LOCATION: /opt/intel/openvino_2021.2.185/
     
  steps:
  
@@ -26,7 +27,6 @@
  
    - script: |
       export TF_LOCATION=/home/iotgecsp/setup/artifacts/tensorflow
-      export OV_LOCATION=/opt/intel/openvino_2021.2.185/ 
       export OPENVINO_TF_BACKEND=CPU
       export BUILD_OPTIONS=--use_grappler_optimizer
       virtualenv -p python3 /home/iotgecsp/azu_ag/myagent/1/s/venv 
@@ -39,13 +39,14 @@
       echo $(WORK_DIR)
       git submodule init
       git submodule update
-      python3 build_ovtf.py --use_tensorflow_from_location=/home/iotgecsp/setup/artifacts --cxx11_abi_version=1
+      python3 build_ovtf.py --use_tensorflow_from_location=/home/iotgecsp/setup/artifacts --use_openvino_from_location=$(OV_LOCATION) --disable_packaging_openvino_libs --cxx11_abi_version=1
      workingDirectory: $(WORK_DIR) 
      displayName: "Build"
      
    - script: |
       export OPENVINO_TF_BACKEND=MYRIAD
       export NGRAPH_TF_UTEST_RTOL=0.0001
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd` python3 test/ci/azure/test_runner.py \
       --artifacts $(WORK_DIR)/build_cmake/artifacts/ --test_cpp
@@ -55,6 +56,7 @@
    - script: |
       export OPENVINO_TF_BACKEND=MYRIAD
       export NGRAPH_TF_UTEST_RTOL=0.0001
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       cd test/ci/azure/      
       bash run_inception_v3.sh $(WORK_DIR)/build_cmake/artifacts/
@@ -72,6 +74,7 @@
       export OPENVINO_TF_BACKEND=MYRIAD
       export NGRAPH_TF_UTEST_RTOL=0.0001
       pip install keras
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd`:`pwd`/tools:`pwd`/examples python3 test/ci/azure/test_runner.py \
       --artifacts $(WORK_DIR)/build_cmake/artifacts --test_python
@@ -82,6 +85,7 @@
       export OPENVINO_TF_BACKEND=MYRIAD
       export NGRAPH_TF_UTEST_RTOL=0.0001
       pip install keras
+      source $(OV_LOCATION)/bin/setupvars.sh
       source $(WORK_DIR)/build_cmake/venv-tf-py3/bin/activate
       PYTHONPATH=`pwd` python3 test/ci/azure/test_runner.py \
         --artifacts $(WORK_DIR)/build_cmake/artifacts --test_tf_python


### PR DESCRIPTION
Since we are already using ABI1 TF for our CI, we can simply use the OpenVINO binaries under /opt/intel/openvino_2021/ without any additional changes