### PR TITLE
Node limit update based on avg nodes

### DIFF
--- a/openvino_tensorflow/deassign_clusters.cc
+++ b/openvino_tensorflow/deassign_clusters.cc
@@ -193,8 +193,8 @@ Status DeassignClusters(Graph* graph) {
 
     int min_non_trivial_nodes = num_nodes_marked_before_deassign >> 5;
     int avg_nodes_marked_before_deassign = num_nodes_marked_before_deassign/cluster_map.size();
-    if (min_non_trivial_nodes < avg_nodes_marked_before_deassign) {
-      min_non_trivial_nodes >>= 1;
+    if (min_non_trivial_nodes < avg_nodes_marked_before_deassign*2) {
+      min_non_trivial_nodes >>= 2;
     }
     if (min_non_trivial_nodes < 6) {
       min_non_trivial_nodes = 6;


### PR DESCRIPTION
Includes an additional condition to check the average number of nodes per cluster before setting the minimum number of trivial node limit. Decreases the limit further if necessary. This will prevent Efficientnet models to fallback to TF.