### PR TITLE
Windows GitHub OD sample rename flag fix.

### DIFF
--- a/examples/common/utils.py
+++ b/examples/common/utils.py
@@ -52,6 +52,7 @@ def rename_file(filePath, out_classes, labels):
 
     img = Image.open(filePath)
     img_exif = img.getexif()
+    img.close()
 
     if len(img_exif) == 0:
         print('Sorry, image has no exif data.')


### PR DESCRIPTION
This PR is about fixing the error while using rename flag in object detection GitHub sample on windows. The following fix is administered :
Close image after getting information in rename_file() method.