### PR TITLE
Cost based fallback adjustment for low latency

### DIFF
--- a/openvino_tensorflow/kernels/encapsulate_op.cc
+++ b/openvino_tensorflow/kernels/encapsulate_op.cc
@@ -99,7 +99,10 @@ NGraphEncapsulateOp::NGraphEncapsulateOp(OpKernelConstruction* ctx)
   m_disable_cost_based_assignment = 0;
   const char* openvino_tf_disable_cost_assignment =
       std::getenv("OPENVINO_TF_DISABLE_COST_ASSIGNMENT");
-  if (openvino_tf_disable_cost_assignment != nullptr) {
+
+  if (BackendManager::DynamicShapesEnabled()) {
+    m_disable_cost_based_assignment = 1;
+  } else if (openvino_tf_disable_cost_assignment != nullptr) {
     if (1 == std::stoi(openvino_tf_disable_cost_assignment)) {
       m_disable_cost_based_assignment = 1;
     }
@@ -233,7 +236,7 @@ void NGraphEncapsulateOp::Compute(OpKernelContext* ctx) {
                  << " ms.";
     // Restore the fallback to false, if TF is taking more time than OVTF for
     // this cluster
-    if (duration_in_ms > s_ovtf_cluster_timings_map[m_cluster_id]) {
+    if (duration_in_ms >= s_ovtf_cluster_timings_map[m_cluster_id]) {
       NGraphClusterManager::SetClusterFallback(m_cluster_id, false);
     }
     // Disable timing run for this cluster


### PR DESCRIPTION
- Cost based fallback disabled for dynamic shapes.
- It will not fallback if the latencies in ms are equal.