### PR TITLE
Change default Python3 to Python3.6 while building Linux wheels using Dockerfile.

### DIFF
--- a/tools/builds/Dockerfile.manylinux_2_27_cxx11
+++ b/tools/builds/Dockerfile.manylinux_2_27_cxx11
@@ -19,8 +19,12 @@ SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 ARG OVTF_BRANCH="releases/2.3.0"
 
+RUN rm /usr/bin/python3 && \
+    ln -s /usr/bin/python3.6 /usr/bin/python3 && \
+    python3 --version
+
 RUN apt-get update; \
-    apt install -y --no-install-recommends software-properties-common && \
+    apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa; \
     apt-get install -y --no-install-recommends \
     git \
@@ -35,7 +39,7 @@ RUN apt-get update; \
     rm -rf /var/lib/apt/lists/*;
 
 RUN apt-get update; \
-    apt install -y --no-install-recommends software-properties-common && \
+    apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa; \
     apt-get install -y --no-install-recommends \
         python3.6-dev python3.7-dev python3.8-dev python3.9-dev && \


### PR DESCRIPTION
This PR includes the following -

- Change default Python3.8 version of OpenVINO docker to Python3.6 to remove apt_pkg error while adding deadsnakes:ppa repository.
- Change apt to apt-get.