### PR TITLE
Disable failing unit tests for Linux CPU, GPU

### DIFF
--- a/test/python/tensorflow/tests_linux_cpu.txt
+++ b/test/python/tensorflow/tests_linux_cpu.txt
@@ -110,7 +110,7 @@ array_ops_test.ShapeSizeRankTest.testSparseShape
 #reduction_ops_test.AnyReductionTest.testAxesType
 #reduction_ops_test.MinReductionTest.testAxesType
 #reduction_ops_test.ProdReductionTest.testAxesType
-#cwise_ops_unary_test.UnaryOpTest.testComplexAbsGradGrad
+cwise_ops_unary_test.UnaryOpTest.testComplexAbsGradGrad
 
 # data doesn't exist
 #concat_op_test.ConcatOpTest.testGradientWithUnknownInputDim
@@ -120,9 +120,9 @@ concat_op_test.ConcatOpTest.testGradientsNegativeAxis
 concat_op_test.ConcatOpTest.testGradientsRandom
 concat_op_test.ConcatOpTest.testGradientsSimple
 concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim0Grad
-#concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim1Grad
-#concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim1Grad_UnknownInputDim
-#concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim2Grad
+concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim1Grad
+concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim1Grad_UnknownInputDim
+concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim2Grad
 #identity_bijector_test.IdentityBijectorTest.testBijector
 math_ops_test.LogSumExpTest.testInfinity
 math_ops_test.LogSumExpTest.testKeepDims
@@ -149,11 +149,11 @@ topk_op_test.TopKTest.testTopKGradients
 reduction_ops_test.SumReductionTest.testInfinity
 reduction_ops_test.SumReductionTest.testInt32
 #reduction_ops_test.MaxReductionTest.testFloatReduce3D
-#reduction_ops_test.MaxReductionTest.testGradient2
+reduction_ops_test.MaxReductionTest.testGradient2
 #reduction_ops_test.MaxReductionTest.testInfinity
 #reduction_ops_test.MaxReductionTest.testInt64Reduce3D
 #reduction_ops_test.MinReductionTest.testFloatReduce3D
-#reduction_ops_test.MinReductionTest.testGradient2
+reduction_ops_test.MinReductionTest.testGradient2
 #reduction_ops_test.MinReductionTest.testInfinity
 reduction_ops_test.ProdReductionTest.testEmptyGradients
 reduction_ops_test.ProdReductionTest.testFloat32
@@ -185,7 +185,7 @@ math_ops_test.DivAndModTest.testConsistent
 # Incorrect precision f64
 #math_ops_test.XdivyTest.testXdivyNoZero
 #math_ops_test.XdivyTest.testXdivyWithZero
-#math_ops_test.XdivyTest.testXdivyWithZeroBroadcast
+math_ops_test.XdivyTest.testXdivyWithZeroBroadcast
 #math_ops_test.Xlog1pyTest.testXlog1pyNoNeg1
 #math_ops_test.Xlog1pyTest.testXlog1pyWithZeroBroadcast
 #softmax_op_test.SoftmaxTest.testDouble
@@ -219,16 +219,16 @@ split_op_test.SplitOpTest.testDegenerateVariable
 split_op_test.SplitOpTest.testSpecialCasesVariable
 
 # Invalid reduction dimension 
-#reduction_ops_test.MaxReductionTest.testGradient
-#reduction_ops_test.MaxReductionTest.testGradient3
+reduction_ops_test.MaxReductionTest.testGradient
+reduction_ops_test.MaxReductionTest.testGradient3
 #reduction_ops_test.MaxReductionTest.testGradient4
 #reduction_ops_test.MinReductionTest.testGradient4
 
 # Requires start >= limit when delta < 0: 0/4
-#reduction_ops_test.MinReductionTest.testGradient3
+reduction_ops_test.MinReductionTest.testGradient3
 #reduction_ops_test.SumReductionTest.testGradient
 #reduction_ops_test.ReducedShapeTest.testZeros
-#reduction_ops_test.MinReductionTest.testGradient
+reduction_ops_test.MinReductionTest.testGradient
 #reduction_ops_test.ReducedShapeTest.testNegAxes
 
 # Gradient tests fail with Intel TF
@@ -346,3 +346,24 @@ cwise_ops_binary_test.BinaryOpTest.testFloatBasic
 
 # Failing after TF-2.7 upgrade
 gather_op_test.GatherTest.testBadAxis
+
+# Failing after TF-2.9.3 upgrade
+concat_op_test.ConcatOpTest.testTensorConcatDim0Grad
+concat_op_test.ConcatOpTest.testTensorConcatDim1Grad
+concat_op_test.ConcatOpTest.testZeroSize
+constant_op_test.ConstantTest.testSparseValuesRaiseErrors
+cwise_ops_binary_test.BinaryOpTest.testBCast_9D
+cwise_ops_binary_test.BinaryOpTest.testComplex128Basic
+cwise_ops_binary_test.BinaryOpTest.testComplex64Basic
+cwise_ops_binary_test.BinaryOpTest.testDoubleBasic
+cwise_ops_unary_test.UnaryOpTest.testDoubleBasic
+cwise_ops_unary_test.UnaryOpTest.testGradGrad
+math_ops_test.AddNTest.testFloat
+spacetobatch_op_test.SpaceToBatchNDTest.testZeroBlockDimsZeroRemainingDims
+split_op_test.SplitOpTest.testGradientsAll
+split_op_test.SplitOpTest.testIdentity
+split_op_test.SplitOpTest.testListOfScalarTensors
+split_op_test.SplitOpTest.testNonexistentDimTensor
+split_op_test.SplitOpTest.testSplitCols
+split_op_test.SplitOpTest.testSplitDim0
+split_op_test.SplitOpTest.testSplitRows

--- a/test/python/tensorflow/tests_linux_gpu.txt
+++ b/test/python/tensorflow/tests_linux_gpu.txt
@@ -67,7 +67,6 @@ cwise_ops_binary_test.BinaryOpTest.testBCast_4D
 cwise_ops_binary_test.BinaryOpTest.testBCast_5A
 cwise_ops_binary_test.BinaryOpTest.testBCast_5B
 cwise_ops_binary_test.BinaryOpTest.testBCast_5C
-cwise_ops_binary_test.BinaryOpTest.testBCast_5D
 #cwise_ops_binary_test.BinaryOpTest.testBCast_6A
 #cwise_ops_binary_test.BinaryOpTest.testBCast_6B
 cwise_ops_binary_test.BinaryOpTest.testBCast_6C
@@ -80,7 +79,6 @@ cwise_ops_binary_test.BinaryOpTest.testBCast_8A
 #cwise_ops_binary_test.BinaryOpTest.testBCast_8B
 cwise_ops_binary_test.BinaryOpTest.testBCast_8C
 cwise_ops_binary_test.BinaryOpTest.testBCast_8D
-cwise_ops_binary_test.BinaryOpTest.testZeroPowGrad
 math_ops_test.AddNTest.testIndexedSlices
 pad_op_test.PadOpTest.testPaddingTypes
 reduction_ops_test.MeanReductionTest.testGradient
@@ -142,11 +140,11 @@ scan_ops_test.CumsumTest.testAxisType
 # data doesn't exist
 #array_ops_test.StridedSliceTest.testTensorIndexing
 #concat_op_test.ConcatOpTest.testGradientWithUnknownInputDim
-#concat_op_test.ConcatOpTest.testGradientsFirstDim
-#concat_op_test.ConcatOpTest.testGradientsLastDim
+concat_op_test.ConcatOpTest.testGradientsFirstDim
+concat_op_test.ConcatOpTest.testGradientsLastDim
 concat_op_test.ConcatOpTest.testGradientsNegativeAxis
-#concat_op_test.ConcatOpTest.testGradientsRandom
-#concat_op_test.ConcatOpTest.testGradientsSimple
+concat_op_test.ConcatOpTest.testGradientsRandom
+concat_op_test.ConcatOpTest.testGradientsSimple
 concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim0Grad
 concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim1Grad
 concat_op_test.ConcatOpTest.testIndexedSlicesConcatDim1Grad_UnknownInputDim
@@ -200,7 +198,7 @@ reduction_ops_test.ProdReductionTest.testInfinity
 
 #gather_nd_op_test.GatherNdTest.testGradientsRank2Slices
 #gather_nd_op_test.GatherNdTest.testGradientsRank2SlicesWithEmptySpace
-#math_ops_test.AddNTest.testGrad
+math_ops_test.AddNTest.testGrad
 
 # Input image format I64 is not supported yet...
 #math_ops_test.DivAndModTest.testConsistent
@@ -397,3 +395,10 @@ cwise_ops_binary_test.BinaryOpTest.testBCast_15A
 cwise_ops_binary_test.BinaryOpTest.testBCast_6A
 cwise_ops_binary_test.BinaryOpTest.testBCast_6B
 cwise_ops_binary_test.BinaryOpTest.testBCast_8B
+
+# Failing after TF-2.9.3 upgrade
+constant_op_test.ConstantTest.testSparseValuesRaiseErrors
+cwise_ops_binary_test.BinaryOpTest.testBCast_5D
+cwise_ops_binary_test.BinaryOpTest.testZeroPowGrad
+math_ops_test.ModTest.testFixed
+spacetobatch_op_test.SpaceToBatchNDTest.testZeroBlockDimsZeroRemainingDims

--- a/test/python/tests_linux_cpu.txt
+++ b/test/python/tests_linux_cpu.txt
@@ -29,6 +29,9 @@ tests_common.txt
 test_bfloat16.TestBfloat16.test_conv2d_bfloat16
 test_bfloat16.TestBfloat16.test_conv2d_cast_bfloat16
 
+# Failing after TF-2.9.3 upgrade
+test_crop_and_resize.TestCropAndResize.test_crop_and_resize_upscale_nearest
+
 # Failed to set Blob with precision not corresponding to user output precision
 #test_elementwise_ops.TestElementwiseOperations.test_less_equal[1.4-1.0-expected0]
 #test_elementwise_ops.TestElementwiseOperations.test_less_equal[-1.0--1.0-expected1]


### PR DESCRIPTION
This PR contains changes in tests list for BRIGDE_PYTHON and TF_PYTHON for Linux CPU and GPU. Failing tests are moved to skip list.